### PR TITLE
Refactor dotfiles for WSL2 support and cross-platform compatibility

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -38,6 +38,10 @@ setw -g mode-keys vi
 # 'v' で選択を始める
 bind -T copy-mode-vi v send -X begin-selection
 
+# WSL2ではクリップボード連携にclip.exeを使用
+if-shell 'test -n "$WSL_DISTRO_NAME"' \
+  'bind -T copy-mode-vi y send -X copy-pipe-and-cancel "clip.exe"'
+
 # fzf コマンドパレット風ウィンドウスイッチャー
 bind w display-popup -E -w 85% -h 70% "~/.local/bin/tmux-switcher"
 
@@ -60,16 +64,8 @@ set-option -g set-titles-string "#S / #W"
 # ================================================
 
 # 256色端末を使用する
-# set-option -g default-terminal screen-256color
-# set -g terminal-overrides 'xterm:colors=256'
-# set -g default-terminal "tmux-256color"
-# set -ag terminal-overrides ",xterm-256color:RGB"
 set -g default-terminal "screen-256color"
-set -ag terminal-overrides ",alacritty:RGB"
-
-# アクティブなペインのみ白っぽく変更（真っ黒は232）
-# set -g window-style 'bg=colour239'
-# set -g window-active-style 'bg=colour234'
+set -ag terminal-overrides ",xterm-256color:RGB"
 
 # enable visual notification
 set-window-option -g monitor-activity on
@@ -78,8 +74,6 @@ set -g visual-activity on
 set -g status-left-length 100
 set -g status-right-length 100
 
-#set -g @nord_tmux_show_status_content "0"
-#set -g @nord_tmux_no_patched_font "1"
 # precmd フックでブランチ名ベースの命名を行うため automatic-rename は無効化
 set -g automatic-rename off
 
@@ -98,11 +92,14 @@ set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
 set -g @plugin "nordtheme/tmux"
 
-set-environment -g PATH "/opt/homebrew/bin:/bin:/usr/bin"
+# PATH設定: macOSではHomebrew、LinuxではLinuxbrew/標準パスを使用
+if-shell 'test "$(uname -s)" = "Darwin"' \
+  'set-environment -g PATH "/opt/homebrew/bin:/usr/local/bin:/bin:/usr/bin"' \
+  'set-environment -g PATH "$HOME/.local/bin:/usr/local/bin:/bin:/usr/bin"'
+
 run-shell '~/.tmux/plugins/tpm/tpm'
 
 # プラグイン読み込み後にキーバインドを上書き
 # (tmux-pain-control が c を new-window に割り当てるため)
 bind C new-window -c "#{pane_current_path}"
 bind c display-popup -E -w 80% -h 30% "~/.local/bin/claude-status dashboard"
-

--- a/gitconfig
+++ b/gitconfig
@@ -1,19 +1,19 @@
 # This is Git's per-user configuration file.
 
 [include]
-  path = /Users/wakwak/delta/themes.gitconfig
+  path = ~/delta/themes.gitconfig
 
 [core]
-  pager = deltaautocrlf
-  autocrlf = inputeditor
+  pager = delta
+  autocrlf = input
   editor = nvim
 
 [user]
-  name = Ryo Sakaguchiemail
+  name = Ryo Sakaguchi
   email = rsakaguchi3125@gmail.com
 
 [ghq]
-  root = /Users/wakwak/src
+  root = ~/src
 
 [alias]
   sw = switch
@@ -42,4 +42,3 @@
 
 [init]
   defaultBranch = master
-

--- a/nvim/lua/plugins/im-select.lua
+++ b/nvim/lua/plugins/im-select.lua
@@ -1,3 +1,8 @@
+-- macOS専用プラグイン: macOS以外では無効化
+if vim.fn.has("mac") ~= 1 then
+  return {}
+end
+
 return {
   "keaising/im-select.nvim",
   event = "VeryLazy",

--- a/pbcopy
+++ b/pbcopy
@@ -1,39 +1,24 @@
-{
-  "title": "Ghostty: Ctrl+T で IME を英数に切り替え",
-  "rules": [
-    {
-      "description": "Ghostty 利用時に Ctrl+T で IME を英数 (ABC) に切り替えてから Ctrl+T を送信",
-      "manipulators": [
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "t",
-            "modifiers": {
-              "mandatory": ["control"],
-              "optional": ["any"]
-            }
-          },
-          "to": [
-            {
-              "select_input_source": {
-                "language": "en"
-              }
-            },
-            {
-              "key_code": "t",
-              "modifiers": ["control"]
-            }
-          ],
-          "conditions": [
-            {
-              "type": "frontmost_application_if",
-              "bundle_identifiers": [
-                "^com\\.mitchellh\\.ghostty$"
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+#!/bin/sh
+# クロスプラットフォーム クリップボードコピー
+# Usage: echo "text" | pbcopy
+#        pbcopy < file.txt
+
+if [ -n "$WSL_DISTRO_NAME" ] || grep -qi microsoft /proc/version 2>/dev/null; then
+  # WSL2
+  clip.exe
+elif [ "$(uname -s)" = "Darwin" ]; then
+  # macOS
+  /usr/bin/pbcopy
+else
+  # Linux (X11/Wayland)
+  if command -v xclip >/dev/null 2>&1; then
+    xclip -selection clipboard
+  elif command -v xsel >/dev/null 2>&1; then
+    xsel --clipboard --input
+  elif command -v wl-copy >/dev/null 2>&1; then
+    wl-copy
+  else
+    echo "Error: No clipboard tool found. Install xclip, xsel, or wl-clipboard." >&2
+    exit 1
+  fi
+fi

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -1,76 +1,71 @@
-#! /bin/bash
+#!/bin/bash
+set -e
 
-cd `dirname $0`
-ROOT=`dirname $(pwd)`
-CONFIG_DIR='~/.config'
+cd "$(dirname "$0")"
+ROOT="$(dirname "$(pwd)")"
 
-ln -sfv $ROOT/ideavimrc $HOME/.ideavimrc
-ln -sfv $ROOT/obsidian.vimrc $HOME/.obsidian.vimrc
-ln -sfv $ROOT/zsh $HOME/.zsh
-ln -sfv $ROOT/zshenv $HOME/.zshenv
-ln -sfv $ROOT/nvim $HOME/.config/nvim
+# OS判定関数
+is_macos() { [[ "$(uname -s)" == "Darwin" ]]; }
+is_linux() { [[ "$(uname -s)" == "Linux" ]]; }
+is_wsl()   { [[ -n "$WSL_DISTRO_NAME" ]] || grep -qi microsoft /proc/version 2>/dev/null; }
 
-if [ ! -d ~/.config/tmux ]; then
-  mkdir -p ~/.config/tmux
-  echo '~/.config/tmux was created'
+# 冪等なシンボリックリンク作成関数
+link_file() {
+  local src="$1" dst="$2"
+  local dst_dir
+  dst_dir="$(dirname "$dst")"
+  if [[ ! -d "$dst_dir" ]]; then
+    mkdir -p "$dst_dir"
+    echo "Created directory: $dst_dir"
+  fi
+  ln -sfv "$src" "$dst"
+}
+
+echo "==> Creating symlinks..."
+
+# 共通シンボリックリンク
+link_file "$ROOT/ideavimrc" "$HOME/.ideavimrc"
+link_file "$ROOT/obsidian.vimrc" "$HOME/.obsidian.vimrc"
+link_file "$ROOT/zsh" "$HOME/.zsh"
+link_file "$ROOT/zshenv" "$HOME/.zshenv"
+link_file "$ROOT/nvim" "$HOME/.config/nvim"
+link_file "$ROOT/config/tmux/tmux.conf" "$HOME/.config/tmux/tmux.conf"
+link_file "$ROOT/config/sheldon/plugins.toml" "$HOME/.config/sheldon/plugins.toml"
+link_file "$ROOT/config/mise/config.toml" "$HOME/.config/mise/config.toml"
+link_file "$ROOT/config/starship.toml" "$HOME/.config/starship.toml"
+link_file "$ROOT/config/git/ignore" "$HOME/.config/git/ignore"
+link_file "$ROOT/gitconfig" "$HOME/.config/git/config"
+
+# ユーティリティスクリプト
+mkdir -p "$HOME/.local/bin"
+link_file "$ROOT/script/claude-status" "$HOME/.local/bin/claude-status"
+link_file "$ROOT/script/tmux-switcher" "$HOME/.local/bin/tmux-switcher"
+
+# macOS専用シンボリックリンク
+if is_macos; then
+  link_file "$ROOT/config/karabiner/assets/complex_modifications/ghostty-ime-off-on-ctrl-t.json" \
+    "$HOME/.config/karabiner/assets/complex_modifications/ghostty-ime-off-on-ctrl-t.json"
 fi
 
-ln -sfv $ROOT/config/tmux/tmux.conf $HOME/.config/tmux/tmux.conf
-
-# claude-status コマンドをパスに追加
-mkdir -p $HOME/.local/bin
-ln -sfv $ROOT/script/claude-status $HOME/.local/bin/claude-status
-ln -sfv $ROOT/script/tmux-switcher $HOME/.local/bin/tmux-switcher
-
-if [ ! -d ~/.config/alacritty ]; then
-  mkdir -p ~/.config/alacritty
-  echo '~/.config/alacritty was created'
+# Linux/WSL2専用シンボリックリンク
+if is_linux; then
+  link_file "$ROOT/config/terminator/config" "$HOME/.config/terminator/config"
+  link_file "$ROOT/keymap/Xmodmap" "$HOME/.Xmodmap"
 fi
 
-ln -sfv $ROOT/config/alacritty/alacritty.yml $HOME/.config/alacritty/alacritty.yml
+echo ""
+echo "==> Installing packages..."
 
-if [ ! -d ~/.config/sheldon ]; then
-  mkdir -p ~/.config/sheldon
-  echo '~/.config/sheldon was created'
-fi
-
-ln -sfv $ROOT/config/sheldon/plugins.toml $HOME/.config/sheldon/plugins.toml
-
-if [ ! -d ~/.config/mise ]; then
-  mkdir -p ~/.config/mise
-  echo '~/.config/mise was created'
-fi
-
-ln -sfv $ROOT/config/mise/config.toml $HOME/.config/mise/config.toml
-
-ln -sfv $ROOT/config/starship.toml $HOME/.config/starship.toml
-
-if [ ! -d ~/.config/git ]; then
-  mkdir -p ~/.config/git
-  echo '~/.config/git was created'
-fi
-
-ln -sfv $ROOT/config/git/ignore $HOME/.config/git/ignore
-
-if [ ! -d ~/.config/karabiner/assets/complex_modifications ]; then
-  mkdir -p ~/.config/karabiner/assets/complex_modifications
-  echo '~/.config/karabiner/assets/complex_modifications was created'
-fi
-
-ln -sfv $ROOT/config/karabiner/assets/complex_modifications/ghostty-ime-off-on-ctrl-t.json $HOME/.config/karabiner/assets/complex_modifications/ghostty-ime-off-on-ctrl-t.json
-
-# 必要なパッケージをインストールする
-
-if ! command -v mise &> /dev/null; then
+# miseのインストール
+if ! command -v mise &> /dev/null && [[ ! -f "$HOME/.local/bin/mise" ]]; then
   curl https://mise.run | sh
 fi
 
-# LinuxかmacOSかを分岐してパッケージをインストールする
-if [ "$(uname)" == "Darwin" ]; then
-  # macOSの場合
-  $ROOT/script/install-neovim.sh
+# OS別パッケージインストール
+if is_macos; then
+  "$ROOT/script/install-tools-macos.sh"
 else
-  # Linuxの場合
+  # Linux共通パッケージ
   sudo apt update
   sudo apt install -y \
     build-essential \
@@ -78,15 +73,46 @@ else
     libssl-dev \
     pkg-config \
     fzf \
-    ripgrep
+    ripgrep \
+    tmux \
+    direnv \
+    jq
+
+  # sheldon (Linuxではcargoでインストール)
+  if ! command -v sheldon &> /dev/null; then
+    if command -v cargo &> /dev/null; then
+      cargo install sheldon
+    else
+      echo "Warning: cargo not found. Install Rust first to get sheldon."
+    fi
+  fi
+
+  # tpm (tmux plugin manager)
+  if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
+    git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
+  fi
+
+  # delta
+  if ! command -v delta &> /dev/null; then
+    echo "Note: Install git-delta manually: https://dandavison.github.io/delta/installation.html"
+  fi
+
+  # WSL2固有のセットアップ
+  if is_wsl; then
+    sudo apt install -y wslu
+  fi
+
   # Neovimのインストール
-  $ROOT/script/install-neovim.sh
+  "$ROOT/script/install-neovim.sh"
 fi
 
 # 言語・ツールのインストール (config/mise/config.toml に定義済み)
+export PATH="$HOME/.local/bin:$PATH"
 mise install -y
 
-# gitの設定
-git config --global user.name "Ryo Sakaguchi"
-git config --global user.email "rsakaguchi3125@gmail.com"
-git config --global ghq.root $HOME/src
+# gitの設定 (gitconfigでカバーされない設定)
+git config --global ghq.root "$HOME/src"
+
+echo ""
+echo "==> Bootstrap complete!"
+echo "    Please restart your shell or run: source ~/.zshenv"

--- a/script/mise.toml
+++ b/script/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-ghq = "latest"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,9 +1,19 @@
 # Created by newuser for 5.8
 
-fpath=( 
-  $HOME/.zsh/functions 
+# OS判定関数
+is_macos() { [[ "$OSTYPE" == darwin* ]]; }
+is_linux() { [[ "$OSTYPE" == linux* ]]; }
+is_wsl()   { [[ -n "$WSL_DISTRO_NAME" ]] || grep -qi microsoft /proc/version 2>/dev/null; }
+
+fpath=(
+  $HOME/.zsh/functions
   "${fpath[@]}"
 )
+
+# Docker CLI completions (macOSのみ、パスが存在する場合)
+if is_macos && [[ -d "$HOME/.docker/completions" ]]; then
+  fpath=($HOME/.docker/completions $fpath)
+fi
 
 source $ZDOTDIR/.zshrc_local
 
@@ -44,6 +54,7 @@ setopt correct
 setopt interactive_comments
 autoload -Uz compinit
 compinit
+
 zstyle ':completion:*:default' menu select=2
 
 ## History
@@ -61,8 +72,18 @@ setopt pushd_ignore_dups
 DIRSTACKSIZE=100
 
 ## alias
-alias ll='ls -lhaG --color=auto'
+if is_macos; then
+  alias ll='ls -lhaG'
+else
+  alias ll='ls -lha --color=auto'
+fi
 alias g='git'
+
+# WSL2用クリップボードエイリアス
+if is_wsl; then
+  alias pbcopy='clip.exe'
+  alias pbpaste='powershell.exe -NoProfile -Command Get-Clipboard'
+fi
 
 # tmux全セッション削除
 function tmux-kill-all() {
@@ -281,9 +302,3 @@ autoload -Uz wt
 
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
-
-# The following lines have been added by Docker Desktop to enable Docker CLI completions.
-fpath=(/Users/wakwak/.docker/completions $fpath)
-autoload -Uz compinit
-compinit
-# End of Docker CLI completions

--- a/zshenv
+++ b/zshenv
@@ -1,3 +1,12 @@
 export ZDOTDIR=$HOME/.zsh
 
-. "$HOME/.cargo/env"
+# XDG Base Directory
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+# cargo
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi


### PR DESCRIPTION
## Summary

- **gitconfig構文修正**: 改行消失による値の連結を修正（`pager = deltaautocrlf` → 正しい改行）
- **WSL2対応**: OS判定関数（`is_macos`/`is_linux`/`is_wsl`）を導入し、クリップボード連携（clip.exe）、PATH設定、パッケージインストールをクロスプラットフォーム化
- **XDG Base Directory準拠**: `zshenv`にXDG環境変数を明示的にexport
- **bootstrap.sh改善**: 冪等な`link_file()`関数導入、OS別分岐整理、不要なalacritty参照削除、Linux用ツールインストール追加
- **tmux.conf修正**: PATH設定を`if-shell`でOS分岐、terminal-overridesを汎用化（`xterm-256color:RGB`）
- **install-neovim.sh改善**: alias追記の冪等化、Linux ARM64対応
- **im-select.nvim**: macOS以外で無効化
- **pbcopy修正**: 誤ったkarabiner JSONをクロスプラットフォームクリップボードスクリプトに置換
- **zshrc整理**: compinit二重呼び出し修正、`ls` aliasのOS分岐、Docker補完パスのハードコード除去
- **不要ファイル削除**: 重複していた`script/mise.toml`を削除

## 変更ファイル (9 files, +201 -158)

| ファイル | 変更内容 |
|---------|---------|
| `gitconfig` | 構文修正、パスポータブル化 |
| `zshenv` | XDG変数export追加、cargo env存在チェック |
| `zsh/.zshrc` | OS判定関数追加、compinit修正、ls alias分岐、WSL2 clipboard |
| `config/tmux/tmux.conf` | PATH分岐、terminal-overrides汎用化、WSL2 clipboard |
| `script/bootstrap.sh` | link_file()関数、OS分岐、Linux用パッケージ、gitconfig XDG配置 |
| `script/install-neovim.sh` | 冪等化、ARM64対応 |
| `nvim/lua/plugins/im-select.lua` | macOS以外で無効化 |
| `pbcopy` | クロスプラットフォームクリップボードスクリプト |
| `script/mise.toml` | 削除（config/mise/config.tomlと重複） |

## Test plan

- [x] shellcheck: bootstrap.sh, install-neovim.sh, install-tools-macos.sh, pbcopy 全て警告ゼロ
- [x] zsh構文チェック: .zshrc, zshenv 構文OK
- [x] gitconfig検証: `git config --file` で全キー・値が正しくパース
- [x] OS判定ロジック: macOS環境で正しく動作確認
- [x] シンボリックリンク先: 全16ファイル/ディレクトリの存在確認
- [x] compinit: 単一呼び出しに修正済み
- [x] nvim im-select.lua: Lua構文チェック通過
- [ ] WSL2環境での動作確認（実機テスト未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)