### PR TITLE
bootstrap と install-neovim を冪等化

### DIFF
--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -28,9 +28,10 @@ $ROOT/script/install-neovim.sh
 # ================================================
 ln -sfv $ROOT/ideavimrc $HOME/.ideavimrc
 ln -sfv $ROOT/obsidian.vimrc $HOME/.obsidian.vimrc
-ln -sfv $ROOT/zsh $HOME/.zsh
+# ディレクトリ向け symlink は -n を付けないと既存 link を辿って中にネストを作る
+ln -sfnv $ROOT/zsh $HOME/.zsh
 ln -sfv $ROOT/zshenv $HOME/.zshenv
-ln -sfv $ROOT/nvim $HOME/.config/nvim
+ln -sfnv $ROOT/nvim $HOME/.config/nvim
 
 if [ ! -d ~/.config/tmux ]; then
   mkdir -p ~/.config/tmux

--- a/script/install-neovim.sh
+++ b/script/install-neovim.sh
@@ -1,19 +1,16 @@
 #! /bin/bash
 
-# Neovimのインストールスクリプト
+# Neovimのインストールスクリプト（冪等）
 # Usage: ./install-neovim.sh
 # Supports: macOS (x86_64, arm64) and Linux (x86_64)
 
 set -e
-
-echo "Installing Neovim..."
 
 # OSとアーキテクチャを検出
 OS=$(uname)
 ARCH=$(uname -m)
 
 if [ "$OS" == "Darwin" ]; then
-  # macOSの場合
   if [ "$ARCH" == "arm64" ]; then
     NVIM_PACKAGE="nvim-macos-arm64.tar.gz"
     NVIM_DIR="nvim-macos-arm64"
@@ -22,16 +19,37 @@ if [ "$OS" == "Darwin" ]; then
     NVIM_DIR="nvim-macos-x86_64"
   fi
 else
-  # Linuxの場合
   NVIM_PACKAGE="nvim-linux-x86_64.tar.gz"
   NVIM_DIR="nvim-linux-x86_64"
 fi
 
-# Neovimのダウンロードとインストール
-curl -LO https://github.com/neovim/neovim/releases/latest/download/$NVIM_PACKAGE
-sudo rm -rf /opt/$NVIM_DIR
-sudo tar -C /opt -xzf $NVIM_PACKAGE
-rm $NVIM_PACKAGE
+NVIM_BIN_PATH="/opt/$NVIM_DIR/bin"
+NVIM_PATH="$NVIM_BIN_PATH/nvim"
+
+# 既存インストール済みバージョンと latest tag を比較し、一致すれば curl/展開を skip
+LATEST_TAG=$(curl -sIL https://github.com/neovim/neovim/releases/latest \
+  | awk 'BEGIN{IGNORECASE=1} /^location:/ {print $2}' \
+  | tail -1 \
+  | awk -F'/' '{print $NF}' \
+  | tr -d '\r\n')
+
+INSTALLED_TAG=""
+if [ -x "$NVIM_PATH" ]; then
+  INSTALLED_TAG=$("$NVIM_PATH" --version | head -1 | awk '{print $2}')
+fi
+
+if [ -n "$LATEST_TAG" ] && [ "$LATEST_TAG" = "$INSTALLED_TAG" ]; then
+  echo "Neovim $INSTALLED_TAG is already up to date at $NVIM_PATH"
+else
+  echo "Installing Neovim ($INSTALLED_TAG -> ${LATEST_TAG:-latest})..."
+  # 途中で失敗してもダウンロード済みアーカイブを残さない
+  trap 'rm -f "$NVIM_PACKAGE"' EXIT
+  curl -LO https://github.com/neovim/neovim/releases/latest/download/$NVIM_PACKAGE
+  sudo rm -rf /opt/$NVIM_DIR
+  sudo tar -C /opt -xzf $NVIM_PACKAGE
+  rm $NVIM_PACKAGE
+  trap - EXIT
+fi
 
 # PATHの設定
 if [ ! -f ~/.zsh/.zshrc_local ]; then
@@ -39,20 +57,21 @@ if [ ! -f ~/.zsh/.zshrc_local ]; then
   touch ~/.zsh/.zshrc_local
 fi
 
-NVIM_BIN_PATH="/opt/$NVIM_DIR/bin"
 if ! grep -q "export PATH=$NVIM_BIN_PATH:\$PATH" ~/.zsh/.zshrc_local; then
   echo "export PATH=$NVIM_BIN_PATH:\$PATH" >> ~/.zsh/.zshrc_local
 fi
 
 # NeovimをVimのデフォルトに設定
-NVIM_PATH="$NVIM_BIN_PATH/nvim"
-
 if [ "$OS" == "Darwin" ]; then
-  # macOSの場合はシンボリックリンクを作成
-  echo 'alias vim="nvim"' >> ~/.zsh/.zshrc_local
-  echo 'alias vi="nvim"' >> ~/.zsh/.zshrc_local
+  # macOS では alias を .zshrc_local に追記（重複防止のため grep でガード）
+  if ! grep -qF 'alias vim="nvim"' ~/.zsh/.zshrc_local; then
+    echo 'alias vim="nvim"' >> ~/.zsh/.zshrc_local
+  fi
+  if ! grep -qF 'alias vi="nvim"' ~/.zsh/.zshrc_local; then
+    echo 'alias vi="nvim"' >> ~/.zsh/.zshrc_local
+  fi
 else
-  # Linuxの場合はupdate-alternativesを使用
+  # Linux では update-alternatives（同一 priority/path での再登録は冪等）
   sudo update-alternatives --install /usr/bin/vim vim $NVIM_PATH 100
   sudo update-alternatives --install /usr/bin/vi vi $NVIM_PATH 100
   sudo update-alternatives --set vim $NVIM_PATH
@@ -61,6 +80,4 @@ fi
 
 git config --global core.editor "nvim"
 
-echo "Neovim installation completed successfully!"
 echo "Installed at: $NVIM_PATH"
-echo "Please restart your shell or run: source ~/.zshenv"


### PR DESCRIPTION
## Summary

bootstrap.sh と install-neovim.sh を再実行安全（冪等）に修正。

## bootstrap.sh

- `zsh` / `nvim` のディレクトリ向け symlink を `ln -sfnv` に変更
- BSD ln（macOS）は対象が既存 symlink でディレクトリを指す場合、`-n` を付けないとリンクを辿って中にネストしたリンクを作る挙動がある（直前 PR #3 で `~/.claude/skills/skills` の事故を踏んだ）

## install-neovim.sh

- 既存インストール済みバージョンと GitHub の latest tag を比較し、一致すれば curl/展開/sudo を skip
  - `curl -sIL` で `releases/latest` のリダイレクト先 URL からタグを取り出し、`/opt/<dir>/bin/nvim --version` の出力と比較
- alias `vim` / `vi` の追記を `grep -qF` でガード。再実行のたびに `~/.zsh/.zshrc_local` に同じ alias 行が重複追記されるバグを修正
- ダウンロード途中で sudo 失敗等が起きても、`script/` にアーカイブが残らないよう `trap` で掃除
- 表示を簡素化（不要な進捗 echo を整理）

## Test plan

- [ ] 既存環境で `bash script/bootstrap.sh` を 2 回実行し、`~/.zsh/.zshrc_local` の `alias vim`/`alias vi` 行がそれぞれ 1 件のままであることを確認
- [ ] Neovim が最新版なら 2 回目以降の bootstrap で curl/展開が走らないことを確認
- [ ] worktree を切り替えて bootstrap を再実行しても `~/.zsh`, `~/.config/nvim` 配下にネストした symlink が作られないことを確認
- [ ] sudo 失敗時に `script/` 配下に tar.gz が残らないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)