### PR TITLE
feat(herdr): split を記号キー (prefix+- / prefix+|) にバインド

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -32,10 +32,10 @@ next_tab = "alt+right"
 previous_workspace = "alt+up"
 next_workspace = "alt+down"
 
-# 分割: prefix+minus (上下) はデフォルトのまま tmux の bind - と一致。
-# tmux の bind | (左右) は herdr のキー構文に pipe が無いためデフォルト prefix+v を使う。
-# split_vertical = "prefix+v"
-# split_horizontal = "prefix+minus"
+# 分割: tmux の bind - (上下) / bind | (左右) を踏襲し、記号キーで直感的に。
+# split_horizontal = 上下分割 (横線 -)、split_vertical = 左右分割 (縦線 |)
+split_horizontal = "prefix+minus"
+split_vertical = "prefix+|"
 
 # workspace_picker = "prefix+w" (デフォルト) が tmux の bind w (switcher) の上位互換
 


### PR DESCRIPTION
## 概要

herdr の pane 分割を、tmux 時代の `bind -` / `bind |` を踏襲した記号キーにバインドする。

## 変更内容

`config/herdr/config.toml` の `[keys]`:

| アクション | キー | 分割 |
|---|---|---|
| `split_horizontal` | `prefix+minus` (`Ctrl+T -`) | 上下分割（横線 `-`） |
| `split_vertical` | `prefix+|` (`Ctrl+T \|`) | 左右分割（縦線 `|`） |

- prefix は既存設定 `ctrl+t` のまま（本 PR では変更なし）
- `reload-config` で起動中セッションにも反映済み

## 確認事項

- `prefix+minus` の `-` は herdr ドキュメント記載の有効記号で問題なし
- `prefix+|` の `|` は herdr の有効記号リスト（minus, comma, ampersand, plus, backtick）に未記載で、shift 併用のため端末依存の可能性あり。実機で `Ctrl+T |` が左右分割になるか要確認。動作しない場合は別キーへ変更する

🤖 Generated with [Claude Code](https://claude.com/claude-code)