### PR TITLE
docs: macos.sh に node を Homebrew 管理しない旨を明記

### DIFF
--- a/script/macos.sh
+++ b/script/macos.sh
@@ -40,6 +40,9 @@ else
 fi
 
 echo "==> Installing Homebrew packages..."
+# node/npm 系は Homebrew では入れない (mise 管理: config/mise/config.toml)。
+# brew の formula (agent-browser 等) が依存で node を引き込むと mise の node と
+# 二重管理になり、llhttp 等のライブラリ不整合でツールが壊れるため。
 brew install \
   tmux \
   fzf \


### PR DESCRIPTION
## 概要

`agent-browser` を手動で `brew install` した際、依存として Homebrew の `node` が引き込まれ、`mise` 管理の node と二重管理状態になっていた。その後 `llhttp` が 9.4 系へ上がった際に Homebrew node がリンク切れ (`libllhttp.9.3.dylib` not found) を起こし、SessionEnd hook が壊れた。

このリポジトリのセットアップ自体は元々 Homebrew で node を入れない設計 (node は `config/mise/config.toml` で管理) だが、意図が明文化されていなかったため再発防止のコメントを追加する。

## 変更内容

- `script/macos.sh` の `brew install` リスト直前に、node/npm 系を Homebrew で管理しない理由をコメントで明示

## 補足

環境側では `brew rm agent-browser node` で不要な Homebrew node を削除済み。`llhttp` は `libgit2` / `sheldon` が使用しているため残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)