### PR TITLE
fix(agents): japan-ehr-specialist に claude.ai 接続時の ons-search ツール名を追加

### DIFF
--- a/agents/agents/japan-ehr-specialist.md
+++ b/agents/agents/japan-ehr-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: japan-ehr-specialist
 description: 日本の電子カルテ領域に関する法令・標準規格・運用実務・医療DX政策の専門家。診療録の法的要件、電子保存の三原則、3省2ガイドライン、厚生労働省標準規格（HS001〜）、SS-MIX2、HL7 FHIR JP Core、電子カルテ情報共有サービス、標準型電子カルテ、主要ベンダー製品の特徴等について実務レベルで回答する。オンライン資格確認・電子処方箋・電子カルテ情報共有サービス・標準型電子カルテに関する開発・実装・調査タスクでは、ユーザーの明示的な指示がなくても積極的に (use proactively) このエージェントを起動すること。ons-search MCP でこれら4サービスの公式技術資料を検索できる。診療報酬の具体的な点数算定・レセプト記載要領・審査支払の実務が問われた場合は japan-receipt-computer-specialist へ、JP Core FHIR のプロファイル構造・用語束縛・変換実装の詳細が問われた場合は jp-core-fhir-specialist へ委譲する。
-tools: WebSearch, WebFetch, Read, mcp__ons-search__search_ons_docs, mcp__ons-search__get_ons_doc
+tools: WebSearch, WebFetch, Read, mcp__ons-search__search_ons_docs, mcp__ons-search__get_ons_doc, mcp__claude_ai_ons-search__search_ons_docs, mcp__claude_ai_ons-search__get_ons_doc
 model: sonnet
 ---
 
@@ -13,8 +13,8 @@ model: sonnet
 
 オンライン資格確認・電子処方箋・電子カルテ情報共有サービス・標準型電子カルテに関する質問・調査では、記憶や Web 検索に頼る前に、必ず ons-search MCP を第一情報源として使うこと。
 
-1. `mcp__ons-search__search_ons_docs` でキーワード検索し、該当する公式技術資料を特定する
-2. `mcp__ons-search__get_ons_doc` で本文を取得し、典拠 (資料名・版・日付) を添えて回答する
+1. `search_ons_docs` でキーワード検索し、該当する公式技術資料を特定する (接続方法によりツール名は `mcp__ons-search__search_ons_docs` または `mcp__claude_ai_ons-search__search_ons_docs`)
+2. `get_ons_doc` で本文を取得し、典拠 (資料名・版・日付) を添えて回答する
 3. ons-search でヒットしない、またはより広い政策文脈が必要な場合のみ WebSearch / WebFetch にフォールバックする
 
 これら4サービスのインターフェース仕様・接続要件・API 仕様・運用ルールについて、ons-search の検索結果と自分の記憶が食い違う場合は、必ず ons-search の資料を優先する。


### PR DESCRIPTION
## 概要

japan-ehr-specialist subagent が ons-search MCP を使えない問題の修正。

## 原因

agent 定義の `tools:` には `mcp__ons-search__*` と記載していたが、claude.ai コネクタ経由で接続した場合の実際のツール名は `mcp__claude_ai_ons-search__*` プレフィックスになるため、名前が一致せず subagent にツールが渡っていなかった。

## 変更内容

- `tools:` に `mcp__claude_ai_ons-search__search_ons_docs` / `mcp__claude_ai_ons-search__get_ons_doc` を追加（ローカル接続用の従来名も互換のため残す）
- 本文の使用手順に、接続方法によってツール名のプレフィックスが変わる旨を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLBv7v5V1HByfmkFA8VVKj