### PR TITLE
feat: hunk を導入し git の既定 pager にする / gitconfig・mise まわりの整理

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ dotfiles/
 │   ├── tmux/tmux.conf       # tmux 設定 (併存期間中のみ。herdr へ移行中)
 │   └── zed/settings.json    # Zed エディタ設定 (macOS)
 ├── docs/             # 設計・移行メモ (herdr-migration.md 等)
-├── gitconfig         # Git グローバル設定
+├── gitconfig         # Git グローバル設定 (-> ~/.gitconfig; 末尾で ~/.gitconfig_local を include)
 ├── nvim/init.lua     # Neovim 設定 (lazy.nvim)
 ├── pbcopy            # pbcopy polyfill (Linux/WSL)
 ├── pbpaste           # pbpaste polyfill (Linux/WSL)
@@ -79,6 +79,7 @@ dotfiles/
 - **sheldon**: プラグイン変更後は `sheldon lock` が必要
 - **mise**: ツール追加/変更後は `mise install` で反映
 - **zshrc_local**: マシン固有設定（gitignore対象）。シェルデバッグ時は `.zshrc` から読み込まれることに注意
+- **gitconfig**: `~/.gitconfig` へ symlink されるので `git config --global` で直接書き換えず、このファイルを編集する。`$HOME` の展開が必要な設定 (git-wt の hook パス等) だけは bootstrap が `~/.gitconfig_local` へ書き出し、`gitconfig` 末尾の include で後勝ちさせる
 
 ## 主要ツールと設定のポイント
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ dotfiles/
 │   ├── git/ignore    # グローバル gitignore
 │   ├── ccstatusline/settings.json # Claude Code ステータスライン (mise: npm:ccstatusline 経由)
 │   ├── herdr/config.toml    # herdr 設定 (prefix: Ctrl+T; tmux からの移行先)
+│   ├── hunk/config.toml     # hunk 設定 (git の既定 pager。テーマは herdr と揃えて kanagawa)
 │   ├── karabiner/    # Karabiner-Elements 設定 (macOS)
 │   ├── mise/config.toml    # ランタイム管理 (Go, Java, Node, Rust, CLI tools)
 │   ├── sheldon/plugins.toml # zsh プラグイン管理
@@ -91,6 +92,12 @@ dotfiles/
 ### zsh
 - FZF ウィジェット: `Ctrl+R`(履歴), `Ctrl+]`(ghq → herdr workspace), `Ctrl+W`(worktree → herdr tab)
 - `git wt` コマンド: git worktree ヘルパー ([k1LoW/git-wt](https://github.com/k1LoW/git-wt)、mise で導入)。worktree 配置・multiplexer 連携・cd は git config (`wt.basedir`/`wt.hook`/`wt.deletehook`/`wt.nocd`) で制御。連携の実体は `script/git-wt-herdr-hook.sh` (herdr 外では `git-wt-tmux-hook.sh` へ委譲)。マージ済み/gone ブランチの掃除は `git wtclean` (= `gh poi` + `git worktree prune`)。全リポジトリ横断は `git wtclean-all` (`script/git-wtclean-all`; worktree を持つ repo だけ対象、`-n` で dry-run)
+
+### hunk (diff viewer。git の既定 pager)
+- `core.pager = hunk pager`。unified diff 以外 (`git log` 等) は `less -R` へ自動フォールバックする
+- 全画面 TUI なので diff がスクロールバックに残らない。残したいときは `git dd` / `git ds` (delta 経由)
+- PR レビューは `git hpr [<PR>]` (= `gh pr diff | hunk patch`)、ファイル単位比較は `git difftool`
+- テーマは herdr と揃えて `kanagawa-wave`。設定は `config/hunk/config.toml`
 
 ### Neovim
 - lazy.nvim でプラグイン管理

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,6 @@ dotfiles/
 │   ├── macos.sh             # macOS 専用セットアップ (Homebrew, GUI app config 等)
 │   ├── wsl.sh               # WSL2/Linux 専用セットアップ (apt, WSL 補助ツール等)
 │   ├── install-tools-macos.sh # macos.sh への互換ラッパー
-│   ├── mise.toml            # mise タスク定義 (ghq等; メイン設定は config/mise/config.toml)
 │   ├── git-wt-herdr-hook.sh # git-wt の herdr 連携 hook (作成/削除時に herdr tab 操作)
 │   ├── git-wt-tmux-hook.sh  # git-wt の tmux 連携 hook (herdr 外のとき herdr hook から委譲される)
 │   └── git-wtclean-all      # 全 ghq リポジトリ横断で git wtclean を実行 (git wtclean-all)

--- a/config/hunk/config.toml
+++ b/config/hunk/config.toml
@@ -1,0 +1,20 @@
+# hunk: review-first terminal diff viewer (https://hunk.dev)
+# 設定リファレンス: https://hunk.dev/docs/reference/config/
+# 優先順位: デフォルト < このファイル < リポジトリの .hunk/config.toml < CLI オプション
+
+# herdr の kanagawa テーマと配色を揃える (組込みの kanagawa dark 系)
+theme = "kanagawa-wave"
+# パネル背景を塗らず端末の背景を透かす。herdr 側の配色と馴染ませるため
+transparent_background = true
+
+# 端末幅に応じて split (左右) と stack (上下) を自動で切り替える
+mode = "auto"
+
+line_numbers = true
+# レビュー中に長い行が画面外に切れると読み落とすため折り返す
+wrap_lines = true
+hunk_headers = true
+menu_bar = true
+
+# Claude Code 等が残した agent note を最初から開いた状態にする
+agent_notes = true

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -18,6 +18,10 @@ ghq = "latest"
 stylua = "latest"
 ruff = "latest"
 golangci-lint = "latest"
+# hunk (review-first terminal diff viewer): mise に brew backend は無く、
+# 公式配布は npm (パッケージ名 hunkdiff / 実行ファイル名 hunk) と brew のみ。
+# WSL/Linux でも同じ経路で入るよう npm backend を採用。
+"npm:hunkdiff" = "latest"
 "npm:@fsouza/prettierd" = "latest"
 "npm:eslint_d" = "latest"
 "npm:ccstatusline" = "latest"

--- a/gitconfig
+++ b/gitconfig
@@ -4,7 +4,9 @@
   path = ~/delta/themes.gitconfig
 
 [core]
-  pager = delta
+  # hunk pager は入力が unified diff かを判定し、diff 以外 (git log 等) は
+  # HUNK_TEXT_PAGER -> PAGER -> less -R へ自動フォールバックする
+  pager = hunk pager
   autocrlf = input
   editor = nvim
 
@@ -25,6 +27,11 @@
   poi = !gh poi
   pr-checks = !gh pr checks
   openpr = !gh pr view --web
+  # PR の diff をそのまま hunk でレビューする
+  hpr = "!f() { gh pr diff \"$@\" | hunk patch; }; f"
+  # 既定の pager は hunk (全画面 TUI)。スクロールバックに残したいときは delta
+  dd = -c core.pager=delta diff
+  ds = -c core.pager=delta show
   wl = worktree list
   wa = worktree add
   wr = worktree remove
@@ -36,6 +43,13 @@
 
 [diff]
   colorMoved = default
+  tool = hunk
+
+[difftool]
+  prompt = false
+
+[difftool "hunk"]
+  cmd = hunk difftool "$LOCAL" "$REMOTE" "$MERGED"
 
 [init]
   defaultBranch = master

--- a/gitconfig
+++ b/gitconfig
@@ -1,4 +1,6 @@
 # This is Git's per-user configuration file.
+# ~/.gitconfig へ symlink される (script/bootstrap.sh)。
+# 絶対パスを含むマシン固有設定は末尾で include する ~/.gitconfig_local 側に置く
 
 [include]
   path = ~/delta/themes.gitconfig
@@ -13,6 +15,9 @@
 [user]
   name = Ryo Sakaguchi
   email = rsakaguchi3125@gmail.com
+
+[ghq]
+  root = ~/src
 
 [alias]
   sw = switch
@@ -36,6 +41,7 @@
   wa = worktree add
   wr = worktree remove
   wp = worktree prune
+  wtclean = !gh poi && git worktree prune
 
 [delta]
   features = collared-trogon
@@ -49,7 +55,28 @@
   prompt = false
 
 [difftool "hunk"]
-  cmd = hunk difftool "$LOCAL" "$REMOTE" "$MERGED"
+  # パスに空白が含まれても壊れないよう、値として残す " はエスケープする
+  cmd = hunk difftool \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
+
+# 空の helper で既定 (osxkeychain 等) をリセットしてから gh に委譲する。
+# gh は mise 管理なので絶対パスではなく PATH 解決させる
+[credential "https://github.com"]
+  helper =
+  helper = !gh auth git-credential
+
+[credential "https://gist.github.com"]
+  helper =
+  helper = !gh auth git-credential
+
+# worktree 配置と cd 挙動。hook (絶対パスが必要) は ~/.gitconfig_local 側で設定する
+[wt]
+  basedir = ../worktree/{gitroot}
+  nocd = create
 
 [init]
   defaultBranch = master
+
+# マシン固有設定 (git-wt の hook パス等)。後勝ちさせるため末尾に置く。
+# 存在しない場合 git は黙って無視する
+[include]
+  path = ~/.gitconfig_local

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -113,7 +113,19 @@ run_platform_setup() {
   esac
 }
 
+link_gitconfig() {
+  # 従来は git config --global で ~/.gitconfig を直接育てていたため、実ファイルが
+  # 残っているマシンがある。symlink へ置き換える前に退避して設定を失わないようにする
+  if [[ -e "$HOME/.gitconfig" && ! -L "$HOME/.gitconfig" ]]; then
+    local backup="$HOME/.gitconfig.bak.$(date +%Y%m%d%H%M%S)"
+    mv "$HOME/.gitconfig" "$backup"
+    echo "==> existing ~/.gitconfig moved to $backup" >&2
+  fi
+  link_file "$ROOT/gitconfig" "$HOME/.gitconfig"
+}
+
 link_common_config() {
+  link_gitconfig
   link_file "$ROOT/ideavimrc" "$HOME/.ideavimrc"
   link_file "$ROOT/obsidian.vimrc" "$HOME/.obsidian.vimrc"
   link_dir "$ROOT/zsh" "$HOME/.zsh"
@@ -264,21 +276,16 @@ cleanup_legacy_wt() {
 }
 
 configure_git() {
-  # gitの設定
-  git config --global user.name "Ryo Sakaguchi"
-  git config --global user.email "rsakaguchi3125@gmail.com"
-  git config --global ghq.root "$HOME/src"
+  # 設定の実体はリポジトリの gitconfig (= ~/.gitconfig へ symlink) 側にある。
+  # ここでは $HOME の展開が必要でファイルに直書きできないものだけを
+  # ~/.gitconfig_local へ書き出す (gitconfig の末尾で include される)。
+  # set (--add ではない) なので bootstrap 再実行でも重複しない。
+  local hook="$HOME/.local/bin/git-wt-herdr-hook.sh"
 
-  # git-wt (git worktree ヘルパー) のグローバル設定
-  # worktree 配置を <repo親>/worktree/<repo名> に揃え、herdr 連携 hook を登録する。
+  # git-wt の worktree 作成/削除に herdr 連携 hook を登録する
   # (herdr hook は herdr 外だと tmux hook へ委譲するので併存期間も両対応)
-  # いずれも set (--add ではない) なので bootstrap 再実行でも重複しない。
-  git config --global wt.basedir "../worktree/{gitroot}"
-  git config --global wt.nocd create
-  git config --global wt.hook "$HOME/.local/bin/git-wt-herdr-hook.sh add"
-  git config --global wt.deletehook "$HOME/.local/bin/git-wt-herdr-hook.sh delete"
-  # マージ済み/gone ブランチの掃除 (旧 wt clean の代替): gh poi + worktree prune
-  git config --global alias.wtclean "!gh poi && git worktree prune"
+  git config --file "$HOME/.gitconfig_local" wt.hook "$hook add"
+  git config --file "$HOME/.gitconfig_local" wt.deletehook "$hook delete"
 }
 
 run_step "Platform setup" run_platform_setup

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -124,6 +124,7 @@ link_common_config() {
   link_file "$ROOT/config/herdr/config.toml" "$HOME/.config/herdr/config.toml"
   link_file "$ROOT/config/sheldon/plugins.toml" "$HOME/.config/sheldon/plugins.toml"
   link_file "$ROOT/config/mise/config.toml" "$HOME/.config/mise/config.toml"
+  link_file "$ROOT/config/hunk/config.toml" "$HOME/.config/hunk/config.toml"
   link_file "$ROOT/config/starship.toml" "$HOME/.config/starship.toml"
   link_file "$ROOT/config/ccstatusline/settings.json" "$HOME/.config/ccstatusline/settings.json"
   link_file "$ROOT/config/git/ignore" "$HOME/.config/git/ignore"

--- a/script/mise.toml
+++ b/script/mise.toml
@@ -1,2 +1,0 @@
-[tools]
-ghq = "latest"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -7,6 +7,11 @@ fpath=(
 
 ## Env
 command -v sheldon >/dev/null 2>&1 && eval "$(sheldon source)"
+
+# マシン固有設定 (Homebrew / gcloud 等の PATH 追加) は mise activate より前に読む。
+# 逆順だと system 側のツールが mise 管理版より優先される (mise doctor が警告する)
+[[ -f "$ZDOTDIR/.zshrc_local" ]] && source "$ZDOTDIR/.zshrc_local"
+
 _mise_bin=""
 if [[ -x "$HOME/.local/bin/mise" ]]; then
   _mise_bin="$HOME/.local/bin/mise"
@@ -15,17 +20,15 @@ elif command -v mise >/dev/null 2>&1; then
 fi
 if [[ -n "$_mise_bin" ]]; then
   eval "$("$_mise_bin" activate zsh)"
-fi
-command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
-# git-wt: git worktree ヘルパー。git() ラッパー関数と補完を有効化 (未インストール時はスキップ)
-command -v git-wt >/dev/null 2>&1 && eval "$(git-wt --init zsh)"
-if [[ -n "$_mise_bin" ]]; then
   JAVA_HOME="$("$_mise_bin" where java 2>/dev/null || true)"
   [[ -n "$JAVA_HOME" ]] && export JAVA_HOME
 fi
 unset _mise_bin
 
-[[ -f "$ZDOTDIR/.zshrc_local" ]] && source "$ZDOTDIR/.zshrc_local"
+# 以下は mise 管理のツール (git-wt 等) を参照するため mise activate の後に置く
+command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
+# git-wt: git worktree ヘルパー。git() ラッパー関数と補完を有効化 (未インストール時はスキップ)
+command -v git-wt >/dev/null 2>&1 && eval "$(git-wt --init zsh)"
 
 bindkey -e
 autoload -Uz add-zsh-hook

--- a/zshenv
+++ b/zshenv
@@ -1,5 +1,8 @@
 export ZDOTDIR="$HOME/.zsh"
 
+# PATH / FPATH の重複を自動排除 (.zshrc_local 等で同じパスが複数回追加されるため)
+typeset -U path PATH fpath FPATH
+
 # sentry
 if [[ -d "$HOME/.local/share/zsh/site-functions" ]]; then
   fpath=("$HOME/.local/share/zsh/site-functions" $fpath)


### PR DESCRIPTION
## 概要

review-first な terminal diff viewer である [hunk](https://hunk.dev/) を導入し、git の既定 pager として使えるところまで設定する。あわせて `gitconfig` の管理方法を symlink に一本化し、`mise doctor` が報告していた既存の環境問題を解消する。

## 変更内容

### hunk の導入 (17e0c72, da26a1e)

- **backend の選定**: 公式配布は npm (`hunkdiff`) と Homebrew のみ。mise に brew backend は無く macOS 限定にもなるため、WSL/Linux でも同じ経路で入る npm backend を採用した
- **`config/hunk/config.toml`**: テーマは herdr と揃えて `kanagawa-wave`、背景は端末へ透過。レビュー中に長い行を見落とさないよう `wrap_lines` を有効化し、agent note は既定で開く
- **`gitconfig`**: `core.pager` を delta から hunk へ変更。`hunk pager` は unified diff 以外を `less -R` へ自動フォールバックするため `git log` 等の挙動は変わらない
  - 全画面 TUI で diff がスクロールバックに残らないため、delta を `git dd` / `git ds` として残した
  - PR レビュー用に `git hpr` (= `gh pr diff | hunk patch`)、ファイル単位比較用に difftool 連携を追加

### gitconfig の symlink 一本化 (89b3a83)

これまで `gitconfig` は `~/.gitconfig` へリンクされておらず、実体は bootstrap の `git config --global` 呼び出しだった。そのため手元の `~/.gitconfig` だけが育ち、リポジトリ側と乖離していた (`ghq.root` / `wt.*` / credential helper 等がローカルにのみ存在)。

- `~/.gitconfig` へ symlink する前提に変更し、ローカルにしか無かった設定を取り込んだ。絶対パス依存を避けるため `ghq.root` は `~/src`、credential helper は PATH 解決される `gh` を使う形にしている
- `$HOME` の展開が必要でファイルに直書きできない設定 (git-wt の hook パス) は、末尾で include する `~/.gitconfig_local` に bootstrap が書き出して後勝ちさせる
- bootstrap は既存の実ファイルを `.gitconfig.bak.<timestamp>` へ退避してから置き換えるので、他マシンで再実行しても設定を失わない

### mise / PATH まわりの整理 (ad5ead2)

`mise doctor` が報告していた2件を解消する。

- **`.zshrc`**: `.zshrc_local` (Homebrew / gcloud 等の PATH 追加) を `mise activate` の前に読むよう順序を入れ替えた。逆順だったため system 側のツールが mise 管理版より優先されていた。あわせて `JAVA_HOME` の設定を activate と同じブロックに統合し、mise 管理の `git-wt` を参照する初期化を activate の後ろへ移動
- **`zshenv`**: `typeset -U` で PATH / FPATH の重複を排除。gitignore 対象の `.zshrc_local` で同じパスが複数回追加されていたため、個別修正ではなく構造的に解決する
- **`script/mise.toml`**: どこからも参照されておらず `config/mise/config.toml` と `ghq` の定義が重複していただけの孤児ファイルのため削除

## 動作確認

- `hunk --version` → `0.17.6`、`config/hunk/config.toml` が読まれ kanagawa 配色・透過背景・折り返しが効くことを実際の描画で確認
- symlink 化の前後で `git config --list --includes` を突き合わせ、差分が意図した汎用化 (絶対パス → `~` / PATH 解決) のみであることを確認。`ghq root` のチルダ展開、delta テーマの include、`git credential fill` による `gh` 経由の認証もそれぞれ実際に確認した
- `difftool.hunk.cmd` は `"` をエスケープしないと git config のパーサーに剥がされ、空白を含むパスで壊れるため、突き合わせで検出してエスケープ済み
- `git dd` (delta 経由) と `git log` (less フォールバック) が従来通り動作することを確認
- クリーンなログインシェル (`env -i zsh -lic`) で mise 管理ツールが PATH 先頭に来ること、PATH に重複が無いことを確認
- `mise doctor` → `No problems found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yZbR45SnTvVY1uo68ye7G