### PR TITLE
feat: hunk-review と herdr の agent skill を bootstrap で登録

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ dotfiles/
 │   │   ├── global/AGENTS.md      # 全プロジェクト共通の個人指示 (-> ~/.codex/AGENTS.md)
 │   │   └── org/<org>/AGENTS.md   # org 単位の個人指示 (gitignore; -> ~/src/github.com/<org>/AGENTS.md)
 │   ├── skills/       # 個人 skills (`gh skill` で Claude Code / Codex に install)
-│   │   └── manifest.tsv # skill ごとの install 先 agent 定義
+│   │   ├── manifest.tsv # skill ごとの install 先 agent 定義
+│   │   └── external.tsv # 外部 repo 由来の skill (skills.sh = `npx skills add` で導入)
 │   ├── agents/       # Claude Code subagent 定義 (spec-planner-*, japan-{ehr,receipt}-* 等)
 │   └── hooks/        # 個人 hooks (worktree-create.sh 等) ※ファイル単位で symlink
 ├── config/           # XDG_CONFIG_HOME 配下の設定
@@ -67,6 +68,7 @@ dotfiles/
 ```
 
 ### WSL2
+
 - Windows 側の WezTerm 設定は dotfiles 管理外。WSL 内の zsh/tmux/nvim/mise 等だけを管理する。
 - repo は `/mnt/c` 配下ではなく WSL filesystem 配下に置く。
 - clipboard は `win32yank.exe` があれば Neovim が優先利用し、なければ `clip.exe`/PowerShell に fallback する。
@@ -84,6 +86,7 @@ dotfiles/
 ## 主要ツールと設定のポイント
 
 ### herdr (マルチプレクサ。tmux から移行中: docs/herdr-migration.md)
+
 - prefix: `Ctrl+T`（tmux 時代を踏襲）
 - 案A「1段スライド」: workspace = repo / tab = branch・worktree / pane = 作業
 - pane 移動: Shift+矢印 / tab 移動: Alt+←→ / workspace 移動: Alt+↑↓
@@ -91,22 +94,27 @@ dotfiles/
 - tmux は併存期間中のみ残る（switcher 系スクリプトは全廃済み）
 
 ### zsh
+
 - FZF ウィジェット: `Ctrl+R`(履歴), `Ctrl+]`(ghq → herdr workspace), `Ctrl+W`(worktree → herdr tab)
 - `git wt` コマンド: git worktree ヘルパー ([k1LoW/git-wt](https://github.com/k1LoW/git-wt)、mise で導入)。worktree 配置・multiplexer 連携・cd は git config (`wt.basedir`/`wt.hook`/`wt.deletehook`/`wt.nocd`) で制御。連携の実体は `script/git-wt-herdr-hook.sh` (herdr 外では `git-wt-tmux-hook.sh` へ委譲)。マージ済み/gone ブランチの掃除は `git wtclean` (= `gh poi` + `git worktree prune`)。全リポジトリ横断は `git wtclean-all` (`script/git-wtclean-all`; worktree を持つ repo だけ対象、`-n` で dry-run)
 
 ### hunk (diff viewer。git の既定 pager)
+
 - `core.pager = hunk pager`。unified diff 以外 (`git log` 等) は `less -R` へ自動フォールバックする
 - 全画面 TUI なので diff がスクロールバックに残らない。残したいときは `git dd` / `git ds` (delta 経由)
 - PR レビューは `git hpr [<PR>]` (= `gh pr diff | hunk patch`)、ファイル単位比較は `git difftool`
+- 同梱の hunk-review skill は bootstrap が `~/.claude/skills/hunk-review` へ symlink する (mise の `latest` 配下を指すためアップグレード追従)
 - テーマは herdr と揃えて `kanagawa-wave`。設定は `config/hunk/config.toml`
 
 ### Neovim
+
 - lazy.nvim でプラグイン管理
 - 2スペースインデント、true color、system clipboard 連携
 
 ## テスト方法
 
 設定変更後の確認:
+
 1. 新しいターミナルで herdr にアタッチし設定が反映されるか確認 (`herdr server reload-config` でも可)
 2. `sheldon lock` がエラーなく完了するか確認
 3. `mise doctor` で mise の状態を確認

--- a/agents/skills/external.tsv
+++ b/agents/skills/external.tsv
@@ -1,0 +1,6 @@
+# 外部リポジトリから skills.sh (npx skills) で導入する skill
+# gh skill は skills/<name>/SKILL.md レイアウトしか認識しないため、
+# repo 直下 SKILL.md 型の skill (herdr 等) は skills.sh で入れる。
+# -g (global) で ~/.agents/skills/ に実体、各 agent へ symlink される。
+# repo	skill
+ogulcancelik/herdr	herdr

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -275,6 +275,27 @@ cleanup_legacy_wt() {
   rm -f "$HOME/.local/bin/wt"
 }
 
+link_hunk_skill() {
+  # hunk 同梱の review skill を Claude Code の個人 skill として登録する。
+  # `hunk skill path` は実バージョン付きパスを返すため、mise の latest symlink 配下を
+  # 優先して hunk アップグレード後もリンク切れしないようにする
+  local hunk_bin skill_dir
+  local latest_dir="$HOME/.local/share/mise/installs/npm-hunkdiff/latest/lib/node_modules/hunkdiff/skills/hunk-review"
+
+  if [[ -f "$latest_dir/SKILL.md" ]]; then
+    skill_dir="$latest_dir"
+  else
+    hunk_bin="$(command -v hunk || true)"
+    if [[ -z "$hunk_bin" ]]; then
+      echo "==> WARN: hunk not found, skipping hunk-review skill link" >&2
+      return 0
+    fi
+    skill_dir="$(dirname "$("$hunk_bin" skill path)")"
+  fi
+
+  link_dir "$skill_dir" "$HOME/.claude/skills/hunk-review"
+}
+
 configure_git() {
   # 設定の実体はリポジトリの gitconfig (= ~/.gitconfig へ symlink) 側にある。
   # ここでは $HOME の展開が必要でファイルに直書きできないものだけを
@@ -319,6 +340,9 @@ run_step "Agent skill install" install_agent_skills
 run_step "Neovim install" bash "$ROOT/script/install-neovim.sh"
 run_step "mise install bootstrap" install_mise
 run_step "mise tool install" run_mise_install
+
+# hunk 同梱 skill の登録 (mise で hunk が入った後に実行する)
+run_step "hunk skill link" link_hunk_skill
 
 # 旧 wt (自前 Go 製) は git-wt へ移行済み。残存バイナリがあれば削除する
 run_step "Legacy wt cleanup" cleanup_legacy_wt

--- a/script/install-agent-skills.sh
+++ b/script/install-agent-skills.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MANIFEST="${1:-$ROOT/agents/skills/manifest.tsv}"
+EXTERNAL_MANIFEST="${EXTERNAL_MANIFEST:-$ROOT/agents/skills/external.tsv}"
 CACHE_ROOT="${AGENT_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles-agent-skills}"
 
 warn() {
@@ -98,10 +99,25 @@ install_skill() {
   gh skill install "$stage_root" "$skill_name" --from-local --agent "$agent" --scope user --force
 }
 
+install_external_skill() {
+  # skills.sh (https://skills.sh) で外部 skill をグローバル導入する。
+  # 実体は ~/.agents/skills/<name> に置かれ、Claude Code 等へは symlink される
+  local repo="$1"
+  local skill_name="$2"
+
+  if ! command -v npx &>/dev/null; then
+    warn "npx not found, skipping external skill $repo/$skill_name"
+    return 0
+  fi
+
+  echo "==> Installing external skill $repo/$skill_name via skills.sh"
+  npx --yes skills add "$repo" --skill "$skill_name" -g
+}
+
 main() {
   require_gh_skill || return 0
 
-  local stage_root skill_path agents agent
+  local stage_root skill_path agents agent repo skill_name
   local -a agent_list
 
   stage_root="$CACHE_ROOT"
@@ -118,6 +134,16 @@ main() {
       install_skill "$stage_root" "$agent" "$skill_path"
     done
   done < "$MANIFEST"
+
+  # 外部 GitHub リポジトリ由来の skill (external.tsv で管理)
+  if [[ -f "$EXTERNAL_MANIFEST" ]]; then
+    while IFS=$'\t' read -r repo skill_name; do
+      [[ -n "$repo" ]] || continue
+      [[ "$repo" == \#* ]] && continue
+
+      install_external_skill "$repo" "$skill_name"
+    done < "$EXTERNAL_MANIFEST"
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## 概要

hunk 同梱の hunk-review skill と herdr skill (ogulcancelik/herdr) を、bootstrap で Claude Code に自動登録するようにする。

## 変更内容

- **bootstrap.sh**: `link_hunk_skill` を追加。hunk 同梱の hunk-review skill を `~/.claude/skills/hunk-review` へ symlink する。`hunk skill path` はバージョン付きパスを返すため、mise の `latest` symlink 配下を優先してアップグレードに追従させる (mise tool install 後のステップとして実行)
- **agents/skills/external.tsv**: 外部 repo 由来 skill の manifest を新設。herdr skill を登録
- **install-agent-skills.sh**: external.tsv を読んで skills.sh (`npx skills add <repo> --skill <name> -g`) で導入するループを追加。gh skill は `skills/<name>/SKILL.md` レイアウトしか認識せず、repo 直下 SKILL.md 型の herdr skill を扱えないため skills.sh を採用
- **CLAUDE.md**: 上記の記載を追記 (見出し後空行の linter 整形を含む)

## 確認

- `bash -n` で両スクリプトの構文チェック
- 実行して `~/.claude/skills/hunk-review` (→ mise latest 配下) と `~/.claude/skills/herdr` (→ `~/.agents/skills/herdr`) の symlink 作成を確認
- Claude Code セッションで両 skill が認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As1CbjFui7AYAhS7jkLEp8