### PR TITLE
feat: review-space skill を追加 (herdr 上にレビュー環境を一発構築)

### DIFF
--- a/agents/skills/manifest.tsv
+++ b/agents/skills/manifest.tsv
@@ -5,3 +5,4 @@ agents/skills/japanese-tech-writing/SKILL.md	claude-code,codex
 agents/skills/dev-task-codex/SKILL.md	claude-code
 agents/skills/spec-planner/SKILL.md	claude-code
 agents/skills/cognitive-rhythm-writing/SKILL.md	claude-code,codex
+agents/skills/review-space/SKILL.md	claude-code

--- a/agents/skills/review-space/SKILL.md
+++ b/agents/skills/review-space/SKILL.md
@@ -9,7 +9,7 @@ description: "コードレビュー環境を herdr 上に一発構築する。re
 
 - 同じ repo の workspace (案A 規約: workspace = repo 名) があればそこへ、なければ workspace を作ってから、review tab を追加して focus する
 - 左 pane: hunk で diff を表示
-  - PR モード: `gh pr diff <PR> | hunk patch` (tab 名 `review:pr<N>`)
+  - PR モード: `gh pr diff <PR> | hunk patch` (tab 名 `review:#<N>`)
   - diff モード (PR なし): `hunk diff --watch <merge-base>` でベースブランチ比較、未コミット・未追跡の変更も含み、コード変更は diff へ自動反映される (tab 名 `review:<base>..<branch>`)
 - 右 pane: Claude Code を起動し、hunk セッションにインラインレビューコメントを書くプロンプトを投入
 - ユーザーは左の hunk でコメントを眺めながらレビューできる

--- a/agents/skills/review-space/SKILL.md
+++ b/agents/skills/review-space/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: review-space
+description: "コードレビュー環境を herdr 上に一発構築する。repo の workspace (なければ作成) に review tab を追加し、hunk (diff 表示) と Claude Code を 2 pane で開いて、Claude Code に hunk セッションへのインラインレビューコメント記入まで自動で任せる。PR があれば PR diff、なければベースブランチとの diff (PR 作成前のセルフレビュー) を対象にする。「レビュー space 開いて」「PR #N をレビュー環境で見たい」「セルフレビューして」「PR 作る前に見ておいて」等で発火。dev-task 等の他 skill が PR 作成前後に呼び出すことも想定。herdr 内 (HERDR_ENV=1) でのみ動作する。"
+---
+
+# review-space
+
+コードレビュー用の herdr tab を一発で組み立てる skill。
+
+- 同じ repo の workspace (案A 規約: workspace = repo 名) があればそこへ、なければ workspace を作ってから、review tab を追加して focus する
+- 左 pane: hunk で diff を表示
+  - PR モード: `gh pr diff <PR> | hunk patch` (tab 名 `review:pr<N>`)
+  - diff モード (PR なし): `hunk diff --watch <merge-base>` でベースブランチ比較、未コミット・未追跡の変更も含み、コード変更は diff へ自動反映される (tab 名 `review:<base>..<branch>`)
+- 右 pane: Claude Code を起動し、hunk セッションにインラインレビューコメントを書くプロンプトを投入
+- ユーザーは左の hunk でコメントを眺めながらレビューできる
+
+## 実行方法
+
+このスキルのディレクトリにあるスクリプトを実行するだけでよい:
+
+```bash
+bash <skill-dir>/scripts/open-review-space.sh [-C <repo-dir>] [PR番号]
+```
+
+- `PR番号` 省略時はカレントブランチの PR を `gh pr view` で解決し、なければ diff モードに自動で切り替わる
+- `-C <repo-dir>`: 対象リポジトリ (worktree) の外から呼ぶときに指定する
+- 再実行は冪等: 同名のレビュアー agent が生きていればその pane に focus するだけで作り直さない (判定はレビュー対象から決定的に生成する agent 名で行う)
+
+実行後はスクリプトの出力 (workspace / tab / pane / agent 名) をそのままユーザーに報告して終了する。**レビュー完了を待たないこと** — レビュアー agent はバックグラウンドで動き続ける。
+
+## 前提条件
+
+- herdr 内で実行していること (`HERDR_ENV=1`)。満たさない場合はその旨を伝えて止まる
+- `herdr` / `jq` / `gh` / `hunk` が PATH にあること
+
+## 他の skill / agent からの呼び出し
+
+PR 作成前後のフックとして呼ぶ場合も同じスクリプトを実行するだけでよい:
+
+```bash
+bash ~/.claude/skills/review-space/scripts/open-review-space.sh -C /path/to/worktree [<PR番号>]
+```
+
+呼び出し元の cwd が対象リポジトリでない場合は `-C` を必ず渡すこと。PR を作った直後に呼ぶなら PR 番号も明示的に渡すのが確実 (ベースブランチ側の cwd では自動解決できないため)。
+
+## 進捗確認・トラブルシュート
+
+- レビューの進み具合: `herdr agent get <agent名>` / `herdr agent read <agent名> --source recent-unwrapped --lines 80`
+- レビュアーが承認待ちで止まっている (`blocked`) 場合は `herdr agent read` で状況を確認してからユーザーに知らせる
+- hunk セッションが見つからないとレビュアーが報告してきた場合は、左 pane の起動失敗を疑い `herdr pane read <hunk pane>` を確認する
+- tab を作り直したいときは `herdr tab close <tab_id>` してから再実行する

--- a/agents/skills/review-space/SKILL.md
+++ b/agents/skills/review-space/SKILL.md
@@ -7,7 +7,7 @@ description: "コードレビュー環境を herdr 上に一発構築する。re
 
 コードレビュー用の herdr tab を一発で組み立てる skill。
 
-- 同じ repo の workspace (案A 規約: workspace = repo 名) があればそこへ、なければ workspace を作ってから、review tab を追加して focus する
+- 同じ repo の workspace (案A 規約: workspace = repo 名) があればそこへ、なければ workspace を作ってから、review tab を追加する。作成は全て no-focus で行い、ユーザーの現在の画面は奪わない (移動は Alt+←→ か `herdr tab focus`)
 - 左 pane: hunk で diff を表示
   - PR モード: `gh pr diff <PR> | hunk patch` (tab 名 `review:#<N>`)
   - diff モード (PR なし): `hunk diff --watch <merge-base>` でベースブランチ比較、未コミット・未追跡の変更も含み、コード変更は diff へ自動反映される (tab 名 `review:<base>..<branch>`)
@@ -24,7 +24,7 @@ bash <skill-dir>/scripts/open-review-space.sh [-C <repo-dir>] [PR番号]
 
 - `PR番号` 省略時はカレントブランチの PR を `gh pr view` で解決し、なければ diff モードに自動で切り替わる
 - `-C <repo-dir>`: 対象リポジトリ (worktree) の外から呼ぶときに指定する
-- 再実行は冪等: 同名のレビュアー agent が生きていればその pane に focus するだけで作り直さない (判定はレビュー対象から決定的に生成する agent 名で行う)
+- 再実行は冪等: 同名のレビュアー agent が生きていれば場所を案内するだけで作り直さない (判定はレビュー対象から決定的に生成する agent 名で行う)
 
 実行後はスクリプトの出力 (workspace / tab / pane / agent 名) をそのままユーザーに報告して終了する。**レビュー完了を待たないこと** — レビュアー agent はバックグラウンドで動き続ける。
 

--- a/agents/skills/review-space/scripts/open-review-space.sh
+++ b/agents/skills/review-space/scripts/open-review-space.sh
@@ -121,12 +121,13 @@ fi
 # herdr は tab label を branch 名で自動上書きするため label は当てにならない
 existing_agent_pane="$(herdr agent list | jq -r --arg n "$agent_name" '.result.agents[] | select(.name == $n) | .pane_id' | head -1)"
 if [[ -n "$existing_agent_pane" ]]; then
-  herdr agent focus "$agent_name" >/dev/null
-  echo "既存のレビュー agent $agent_name (pane $existing_agent_pane) に focus した。作り直す場合は先にその tab を閉じること"
+  echo "レビュー agent $agent_name が既に pane $existing_agent_pane で動いている。作り直す場合は先にその tab を閉じること"
   exit 0
 fi
 
-created="$(herdr tab create --workspace "$ws_id" --cwd "$repo" --label "$tab_label" --focus)"
+# ユーザーの現在の画面を奪わないよう、作成は全て no-focus で行う。
+# tab が UI focus されていなければ agent start も tab 内 focus (hunk 側) を動かさない
+created="$(herdr tab create --workspace "$ws_id" --cwd "$repo" --label "$tab_label" --no-focus)"
 tab_id="$(jq -r '.result.tab.tab_id' <<<"$created")"
 hunk_pane="$(jq -r '.result.root_pane.pane_id' <<<"$created")"
 [[ -n "$tab_id" && -n "$hunk_pane" ]] || die "tab 作成に失敗: $created"
@@ -210,10 +211,7 @@ cleanup_tab_id=""
 # レビュー対象が一目でわかるよう tab をラベル付けする。pane 起動中は worktree 統合の
 # 自動タイトル (branch 名) に上書きされるため、起動が落ち着いたこの時点で行う
 herdr tab rename "$tab_id" "$tab_label" >/dev/null 2>&1 || true
-
-# agent start が tab 内 focus を agent pane へ移すため hunk 側へ戻す。
-# ここが agent 側のままだとユーザーのキー入力が hunk に届かず「ショートカットが効かない」状態になる
-herdr pane focus --direction left --pane "$agent_pane" >/dev/null 2>&1 || true
+# 注意: pane focus / tab focus はここで使わない。UI focus ごとユーザーを引っ張ってしまう
 
 cat <<EOF
 レビュー tab を作成した:
@@ -223,5 +221,6 @@ cat <<EOF
   hunk session:   ${hunk_session:-"(ID 特定失敗: --repo で fallback)"}
   agent:          $agent_name (pane $agent_pane, レビュー実行中)
 対象: $target_desc
+focus は移していない。移動: herdr tab focus $tab_id (または Alt+←→)
 進捗確認: herdr agent get $agent_name / herdr agent read $agent_name --source recent-unwrapped --lines 80
 EOF

--- a/agents/skills/review-space/scripts/open-review-space.sh
+++ b/agents/skills/review-space/scripts/open-review-space.sh
@@ -11,10 +11,13 @@
 
 set -euo pipefail
 
+# tab 作成後に失敗した場合は中途半端な tab を残さず、再実行を安全にする。
+# die() 経由に限らず set -e の暗黙 exit でも走るよう EXIT trap で行う
+cleanup_tab_id=""
+trap '[[ -n "$cleanup_tab_id" ]] && herdr tab close "$cleanup_tab_id" >/dev/null 2>&1 || true' EXIT
+
 die() {
   echo "error: $*" >&2
-  # tab 作成後に失敗した場合は中途半端な tab を残さず、再実行を安全にする
-  [[ -n "${cleanup_tab_id:-}" ]] && herdr tab close "$cleanup_tab_id" >/dev/null 2>&1
   exit 1
 }
 
@@ -46,8 +49,12 @@ if [[ -z "$pr" ]]; then
   # PR がなければエラーにせず diff モード (PR 作成前のセルフレビュー) に落とす。
   # merged/closed も返ってくるので open な PR だけを対象にする
   pr="$(gh pr view --json number,state --jq 'select(.state == "OPEN") | .number' 2>/dev/null || true)"
+else
+  [[ "$pr" =~ ^[0-9]+$ ]] || die "PR 番号が不正: $pr"
+  # 存在しない番号だと後段の gh pr diff の失敗が「hunk の起動を確認できない」に
+  # 化けて原因を追いにくいため、ここで検証して具体的なエラーで止める
+  gh pr view "$pr" --json number >/dev/null 2>&1 || die "PR #$pr を取得できない (番号と gh auth を確認すること)"
 fi
-[[ -z "$pr" || "$pr" =~ ^[0-9]+$ ]] || die "PR 番号が不正: $pr"
 
 repo_name="$(basename "$repo")"
 branch="$(git branch --show-current 2>/dev/null)"
@@ -59,7 +66,10 @@ if [[ -n "$pr" ]]; then
   mode="pr"
   tab_label="review:#${pr}"
   target_desc="PR #${pr}"
-  hunk_cmd="gh pr diff $pr | hunk patch"
+  # stdin パイプだと hunk がキーボードを読めなくなる (stdin が TTY でなくなる) ため、
+  # patch は一時ファイルに落としてから開く
+  patch_file="${TMPDIR:-/tmp}/review-space-$(printf '%s' "$repo_name" | tr -c 'a-zA-Z0-9_-' '-')-pr${pr}.patch"
+  hunk_cmd="gh pr diff $pr > \"$patch_file\" && hunk patch \"$patch_file\""
 else
   mode="diff"
   # ベースブランチは origin/HEAD -> gh -> main/master の順で解決する
@@ -162,17 +172,21 @@ start_hunk() {
 }
 start_hunk || start_hunk || die "hunk の起動を確認できない (pane $hunk_pane)"
 
-# 今回の pane が張った hunk セッション ID を特定する (取れなければ --repo 指定に fallback)
+# 今回の pane が張った hunk セッション ID を特定する (取れなければ --repo 指定に fallback)。
+# 待機中に別の場所で hunk が開かれても誤って掴まないよう cwd でも絞り込む
 hunk_session=""
 for _ in $(seq 1 10); do
-  hunk_session="$(hunk session list --json 2>/dev/null | jq -r '.sessions[].sessionId' 2>/dev/null | grep -vxF -f <(printf '%s\n' "$sessions_before") | head -1 || true)"
+  hunk_session="$(hunk session list --json 2>/dev/null \
+    | jq -r --arg cwd "$repo" '.sessions[] | select(.cwd == $cwd) | .sessionId' 2>/dev/null \
+    | grep -vxF -f <(printf '%s\n' "$sessions_before") | head -1 || true)"
   [[ -n "$hunk_session" ]] && break
   sleep 0.5
 done
 if [[ -n "$hunk_session" ]]; then
   sess_sel="$hunk_session"
 else
-  sess_sel="--repo ${repo}"
+  # プロンプトへそのまま埋め込まれるため、空白入りパスでも壊れないようクォート込みにする
+  sess_sel="--repo \"${repo}\""
 fi
 
 if [[ "$mode" == "pr" ]]; then

--- a/agents/skills/review-space/scripts/open-review-space.sh
+++ b/agents/skills/review-space/scripts/open-review-space.sh
@@ -57,7 +57,7 @@ branch_short="${branch##*/}"
 merge_base=""
 if [[ -n "$pr" ]]; then
   mode="pr"
-  tab_label="review:pr${pr}"
+  tab_label="review:#${pr}"
   target_desc="PR #${pr}"
   hunk_cmd="gh pr diff $pr | hunk patch"
 else

--- a/agents/skills/review-space/scripts/open-review-space.sh
+++ b/agents/skills/review-space/scripts/open-review-space.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# コードレビュー用の herdr tab を一発で組み立てる。
+#   左 pane: hunk (PR があれば gh pr diff | hunk patch、なければベースブランチとの diff)
+#   右 pane: Claude Code (hunk セッションへインラインコメントを書くレビュアー)
+# workspace は 案A 規約 (workspace = repo) に従い、同じ repo の workspace が
+# あればそこへ review tab を追加し、なければ repo 名で workspace を作る。
+# herdr 内 (HERDR_ENV=1) からの実行が前提。他の skill / agent からも直接呼べる。
+#
+# usage: open-review-space.sh [-C <repo-dir>] [PR番号]
+#   PR番号省略時: カレントブランチの PR を解決し、なければ diff モードになる
+
+set -euo pipefail
+
+die() {
+  echo "error: $*" >&2
+  # tab 作成後に失敗した場合は中途半端な tab を残さず、再実行を安全にする
+  [[ -n "${cleanup_tab_id:-}" ]] && herdr tab close "$cleanup_tab_id" >/dev/null 2>&1
+  exit 1
+}
+
+repo_dir=""
+while getopts "C:h" opt; do
+  case "$opt" in
+    C) repo_dir="$OPTARG" ;;
+    h)
+      # 先頭ヘッダブロックだけを usage として出す (本文中のコメントは含めない)
+      sed -n '2,/^$/{s/^# \{0,1\}//p;}' "$0"
+      exit 0
+      ;;
+    *) exit 2 ;;
+  esac
+done
+shift $((OPTIND - 1))
+pr="${1:-}"
+
+[[ "${HERDR_ENV:-}" == "1" ]] || die "herdr の外では実行できない (HERDR_ENV != 1)"
+for cmd in herdr jq gh hunk git; do
+  command -v "$cmd" >/dev/null 2>&1 || die "$cmd が見つからない"
+done
+
+[[ -n "$repo_dir" ]] && cd "$repo_dir"
+repo="$(git rev-parse --show-toplevel 2>/dev/null)" || die "git リポジトリ内で実行すること"
+cd "$repo"
+
+if [[ -z "$pr" ]]; then
+  # PR がなければエラーにせず diff モード (PR 作成前のセルフレビュー) に落とす。
+  # merged/closed も返ってくるので open な PR だけを対象にする
+  pr="$(gh pr view --json number,state --jq 'select(.state == "OPEN") | .number' 2>/dev/null || true)"
+fi
+[[ -z "$pr" || "$pr" =~ ^[0-9]+$ ]] || die "PR 番号が不正: $pr"
+
+repo_name="$(basename "$repo")"
+branch="$(git branch --show-current 2>/dev/null)"
+branch_short="${branch##*/}"
+[[ -n "$branch_short" ]] || branch_short="detached"
+
+merge_base=""
+if [[ -n "$pr" ]]; then
+  mode="pr"
+  tab_label="review:pr${pr}"
+  target_desc="PR #${pr}"
+  hunk_cmd="gh pr diff $pr | hunk patch"
+else
+  mode="diff"
+  # ベースブランチは origin/HEAD -> gh -> main/master の順で解決する
+  base_ref="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [[ -z "$base_ref" ]]; then
+    default_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null || true)"
+    [[ -n "$default_branch" ]] && base_ref="origin/$default_branch"
+  fi
+  if [[ -z "$base_ref" ]]; then
+    for b in main master; do
+      if git show-ref --verify --quiet "refs/remotes/origin/$b"; then
+        base_ref="origin/$b"
+        break
+      fi
+    done
+  fi
+  [[ -n "$base_ref" ]] || die "ベースブランチを解決できない。PR 番号を指定するか origin/HEAD を設定すること"
+  # 未 rebase のブランチでも余計な差分が混ざらないよう merge-base 起点で比較する。
+  # working tree との比較なので、未コミット・未追跡の変更もレビュー対象に入る
+  merge_base="$(git merge-base "$base_ref" HEAD)" || die "merge-base を解決できない ($base_ref...HEAD)"
+  tab_label="review:${base_ref#origin/}..${branch_short}"
+  target_desc="${base_ref}...${branch_short} (working tree 含む)"
+  # --watch でコード変更を diff へ自動反映する (patch モードの PR レビューでは使えない)
+  hunk_cmd="hunk diff --watch $merge_base"
+fi
+
+# workspace 名は git-wt hook と同じ規約: メイン worktree のディレクトリ名 ('.' -> '_')。
+# パスに空白があっても壊れないよう porcelain 出力から取る
+main_root="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+ws_label="$(basename "$main_root" | tr '.' '_')"
+
+# agent 名は herdr の制約 ([a-z][a-z0-9_-]{0,31}) に収める。
+# suffix は branch のフルパス基準 (a/fix と b/fix の衝突回避)
+agent_suffix="${pr:+pr${pr}}"
+[[ -n "$agent_suffix" ]] || agent_suffix="${branch:-detached}"
+agent_name="$(printf 'rev-%s-%s' "$repo_name" "$agent_suffix" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-')"
+if (( ${#agent_name} > 32 )); then
+  # 単純な切り詰めは似た名前同士で衝突して冪等判定が誤 focus するため hash を付ける
+  name_hash="$(printf '%s' "$agent_name" | cksum | awk '{print $1}')"
+  agent_name="${agent_name:0:26}-$(printf '%05d' "$((name_hash % 100000))")"
+fi
+[[ "$agent_name" =~ ^[a-z] ]] || agent_name="r${agent_name:0:31}"
+
+# 同じ repo の workspace があればそこへ tab を足し、なければ規約どおりの名前で作る
+ws_id="$(herdr workspace list | jq -r --arg l "$ws_label" '.result.workspaces[] | select(.label == $l) | .workspace_id' | head -1)"
+if [[ -z "$ws_id" ]]; then
+  ws_id="$(herdr workspace create --cwd "$main_root" --label "$ws_label" --no-focus | jq -r '.result.workspace.workspace_id')"
+  [[ -n "$ws_id" ]] || die "workspace 作成に失敗"
+fi
+
+# 再実行の冪等性は tab label ではなく live agent 名で判定する。
+# herdr は tab label を branch 名で自動上書きするため label は当てにならない
+existing_agent_pane="$(herdr agent list | jq -r --arg n "$agent_name" '.result.agents[] | select(.name == $n) | .pane_id' | head -1)"
+if [[ -n "$existing_agent_pane" ]]; then
+  herdr agent focus "$agent_name" >/dev/null
+  echo "既存のレビュー agent $agent_name (pane $existing_agent_pane) に focus した。作り直す場合は先にその tab を閉じること"
+  exit 0
+fi
+
+created="$(herdr tab create --workspace "$ws_id" --cwd "$repo" --label "$tab_label" --focus)"
+tab_id="$(jq -r '.result.tab.tab_id' <<<"$created")"
+hunk_pane="$(jq -r '.result.root_pane.pane_id' <<<"$created")"
+[[ -n "$tab_id" && -n "$hunk_pane" ]] || die "tab 作成に失敗: $created"
+cleanup_tab_id="$tab_id"
+
+# ratio は first-child (分割元 = hunk 側) の割合。hunk 2/3 : agent 1/3
+agent_pane="$(herdr pane split "$hunk_pane" --direction right --ratio 0.67 --cwd "$repo" --no-focus | jq -r '.result.pane.pane_id')"
+[[ -n "$agent_pane" ]] || die "pane split に失敗"
+
+# split 直後はシェルがプロンプトに達しておらず agent_pane_busy になるため再試行する。
+# agent start 自体はエージェントの起動完了までブロックするので、この待ち時間が
+# hunk 側 pane のシェル起動待ちも兼ねる (hunk の起動はこの後に回す)
+started=""
+for _ in $(seq 1 20); do
+  if out="$(herdr agent start "$agent_name" --kind claude --pane "$agent_pane" 2>&1)"; then
+    started=1
+    break
+  fi
+  grep -q agent_pane_busy <<<"$out" || die "agent start に失敗: $out"
+  sleep 0.5
+done
+[[ -n "$started" ]] || die "agent 用 pane のシェルが起動しない: $out"
+
+# 起動前の hunk セッション一覧を控えておき、後で新規セッション ID を特定する。
+# 同じ repo の古いセッションが残っていると --repo 指定ではそちらを掴んでしまうため
+sessions_before="$(hunk session list --json 2>/dev/null | jq -r '.sessions[].sessionId' 2>/dev/null || true)"
+
+# agent start の入力注入が hunk 側 pane に紛れることがあるため、
+# 起動前に入力行を掃除し、起動後は hunk プロセスの存在まで検証する
+start_hunk() {
+  herdr pane send-keys "$hunk_pane" ctrl+c ctrl+u >/dev/null 2>&1 || true
+  herdr pane run "$hunk_pane" "$hunk_cmd" >/dev/null
+  for _ in $(seq 1 10); do
+    if herdr pane process-info --pane "$hunk_pane" | jq -e '.result.process_info.foreground_processes[]? | select(.name == "hunk")' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+start_hunk || start_hunk || die "hunk の起動を確認できない (pane $hunk_pane)"
+
+# 今回の pane が張った hunk セッション ID を特定する (取れなければ --repo 指定に fallback)
+hunk_session=""
+for _ in $(seq 1 10); do
+  hunk_session="$(hunk session list --json 2>/dev/null | jq -r '.sessions[].sessionId' 2>/dev/null | grep -vxF -f <(printf '%s\n' "$sessions_before") | head -1 || true)"
+  [[ -n "$hunk_session" ]] && break
+  sleep 0.5
+done
+if [[ -n "$hunk_session" ]]; then
+  sess_sel="$hunk_session"
+else
+  sess_sel="--repo ${repo}"
+fi
+
+if [[ "$mode" == "pr" ]]; then
+  intent_step="1. \`gh pr view ${pr}\` で PR の意図・説明を把握する"
+  closing="4. 最後に総評 (重要な指摘・マージ可否の所感) を短く報告する"
+else
+  intent_step="1. \`git log --oneline ${merge_base}..HEAD\` と diff 全体から変更の意図を把握する (PR 作成前のセルフレビュー)"
+  closing="4. 最後に総評 (重要な指摘・PR を作る前に直すべき点) を短く報告する"
+fi
+
+prompt="${target_desc} (${repo_name}) のコードレビューをしてください。左の pane で \`${hunk_cmd}\` の hunk セッションが開いています。
+
+手順:
+${intent_step}
+2. hunk-review skill を使い、\`hunk session review ${sess_sel} --json\` で diff の構造を確認する。内容 (ファイル一覧) が今回のレビュー対象と明らかに食い違う場合は \`hunk session list\` で正しいセッションを選び直すこと
+3. レビューコメントを \`hunk session comment apply ${sess_sel} --stdin\` でまとめてインラインコメントとして追加する
+${closing}
+
+コメントは実害のある指摘・設計上の懸念・見落としやすい点に絞り、全 hunk に機械的に付けないこと。"
+
+herdr agent prompt "$agent_name" "$prompt" >/dev/null
+cleanup_tab_id=""
+
+# レビュー対象が一目でわかるよう tab をラベル付けする。pane 起動中は worktree 統合の
+# 自動タイトル (branch 名) に上書きされるため、起動が落ち着いたこの時点で行う
+herdr tab rename "$tab_id" "$tab_label" >/dev/null 2>&1 || true
+
+cat <<EOF
+レビュー tab を作成した:
+  workspace:      $ws_id ($ws_label)
+  tab:            $tab_id ($tab_label)
+  hunk pane:      $hunk_pane ($hunk_cmd)
+  hunk session:   ${hunk_session:-"(ID 特定失敗: --repo で fallback)"}
+  agent:          $agent_name (pane $agent_pane, レビュー実行中)
+対象: $target_desc
+進捗確認: herdr agent get $agent_name / herdr agent read $agent_name --source recent-unwrapped --lines 80
+EOF

--- a/agents/skills/review-space/scripts/open-review-space.sh
+++ b/agents/skills/review-space/scripts/open-review-space.sh
@@ -66,10 +66,7 @@ if [[ -n "$pr" ]]; then
   mode="pr"
   tab_label="review:#${pr}"
   target_desc="PR #${pr}"
-  # stdin パイプだと hunk がキーボードを読めなくなる (stdin が TTY でなくなる) ため、
-  # patch は一時ファイルに落としてから開く
-  patch_file="${TMPDIR:-/tmp}/review-space-$(printf '%s' "$repo_name" | tr -c 'a-zA-Z0-9_-' '-')-pr${pr}.patch"
-  hunk_cmd="gh pr diff $pr > \"$patch_file\" && hunk patch \"$patch_file\""
+  hunk_cmd="gh pr diff $pr | hunk patch"
 else
   mode="diff"
   # ベースブランチは origin/HEAD -> gh -> main/master の順で解決する
@@ -213,6 +210,10 @@ cleanup_tab_id=""
 # レビュー対象が一目でわかるよう tab をラベル付けする。pane 起動中は worktree 統合の
 # 自動タイトル (branch 名) に上書きされるため、起動が落ち着いたこの時点で行う
 herdr tab rename "$tab_id" "$tab_label" >/dev/null 2>&1 || true
+
+# agent start が tab 内 focus を agent pane へ移すため hunk 側へ戻す。
+# ここが agent 側のままだとユーザーのキー入力が hunk に届かず「ショートカットが効かない」状態になる
+herdr pane focus --direction left --pane "$agent_pane" >/dev/null 2>&1 || true
 
 cat <<EOF
 レビュー tab を作成した:


### PR DESCRIPTION
## 概要

「PR を作ったら herdr に hunk + Claude Code の 2 pane レビュー環境を開いてインラインコメントを書かせる」運用を一発で行う `review-space` skill を追加する。

## 動作

`bash ~/.claude/skills/review-space/scripts/open-review-space.sh [-C <repo-dir>] [PR番号]`

- repo の workspace (案A 規約: workspace = repo 名、git-wt hook と同じ命名) に review tab を追加。workspace がなければ作る
- 左 pane (2/3): hunk で diff 表示
  - PR モード: open な PR があれば `gh pr diff <N> | hunk patch`
  - diff モード: PR がなければ merge-base 起点の `hunk diff --watch` (working tree 含む。コード変更は diff へ自動反映)
- 右 pane (1/3): Claude Code を起動し、hunk セッションへのインラインコメント記入プロンプトを投入
- tab ラベルはレビュー対象がわかる形 (`review:pr<N>` / `review:<base>..<branch>`) に rename
- 再実行はレビュアー agent 名 (`rev-<repo>-<pr|branch>`) による冪等判定で focus のみ
- `/review-space` として起動できるほか、他 skill / agent からもスクリプト直接実行で呼べる

## 実機テストで潰した問題

- pane split 直後の `agent start` が `agent_pane_busy` で失敗 → リトライループ
- agent 起動時の入力注入が hunk pane に紛れて起動失敗 → 起動前の入力行掃除 + process-info による起動検証とリトライ
- herdr が tab label を branch 名で自動上書きし label ベースの冪等判定が不成立 → agent 名判定に変更。rename は pane 起動が落ち着いた後に実行
- 同 repo の stale な hunk セッションを `--repo` で誤って掴む → 新規セッション ID を特定してプロンプトに埋め込む
- merged/closed PR を PR モードで掴む → `state == OPEN` のみ対象
- agent 名の 32 文字切り詰め衝突、空白入り worktree パスのパース、失敗時の中途半端な tab 残留にも対処

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjZfq4FNVpCcqYnnceWw8S